### PR TITLE
Mod codegen bug

### DIFF
--- a/arbitrum/evm/compile.py
+++ b/arbitrum/evm/compile.py
@@ -283,14 +283,14 @@ def generate_contract_code(label, code, code_tuple, contract_id, code_size, code
                 vm.dup2()
                 vm.iszero()
                 vm.ifelse(
-                    lambda vm: vm.pop(),
+                    lambda vm: [vm.pop(), vm.pop()],
                     lambda vm: vm.addmod()
                 )
             elif instr.name == "MULMOD":
                 vm.dup2()
                 vm.iszero()
                 vm.ifelse(
-                    lambda vm: vm.pop(),
+                    lambda vm: [vm.pop(), vm.pop()],
                     lambda vm: vm.mulmod()
                 )
             elif instr.name == "EXP":

--- a/arbitrum/tests/test_arith.py
+++ b/arbitrum/tests/test_arith.py
@@ -18,7 +18,7 @@ from arbitrum.std import arith
 from arbitrum import VM
 
 
-class TestArish(TestCase):
+class TestArith(TestCase):
     def test_max(self):
         vm = VM()
         vm.push(10)


### PR DESCRIPTION
Compiler was generating incorrect code when doing EVM mulmod/addmod instructions, in the case where the modulus is zero. EVM specifies that these instructions should produce zero when the modulus is zero. Compiler was checking for that case, but removed one too few operands from the stack when it occurred.